### PR TITLE
Replaced Configuration usage with HdfsConfiguration

### DIFF
--- a/src/main/java/com/teragrep/cfe_39/consumers/kafka/HDFSWrite.java
+++ b/src/main/java/com/teragrep/cfe_39/consumers/kafka/HDFSWrite.java
@@ -120,6 +120,7 @@ public class HDFSWrite implements AutoCloseable {
             // enable kerberus
             conf.set("hadoop.security.authentication", config.getHadoopAuthentication());
             conf.set("hadoop.security.authorization", config.getHadoopAuthorization());
+            conf.set("hadoop.kerberos.keytab.login.autorenewal.enabled", "true");
 
             conf.set("fs.defaultFS", hdfsuri); // Set FileSystem URI
             conf.set("fs.hdfs.impl", DistributedFileSystem.class.getName()); // Maven stuff?

--- a/src/main/java/com/teragrep/cfe_39/consumers/kafka/HDFSWrite.java
+++ b/src/main/java/com/teragrep/cfe_39/consumers/kafka/HDFSWrite.java
@@ -47,9 +47,9 @@ package com.teragrep.cfe_39.consumers.kafka;
 
 import com.google.gson.JsonObject;
 import com.teragrep.cfe_39.Config;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -66,7 +66,7 @@ public class HDFSWrite implements AutoCloseable {
     private final String path;
     private final FileSystem fs;
     private final boolean useMockKafkaConsumer; // Defines if mock HDFS database is used for testing
-    private final Configuration conf;
+    private final HdfsConfiguration conf;
     private final String hdfsuri;
 
     public HDFSWrite(Config config, JsonObject lastObjectJo) throws IOException {
@@ -86,7 +86,7 @@ public class HDFSWrite implements AutoCloseable {
             fileName = lastObjectJo.get("partition").getAsString() + "." + lastObjectJo.get("offset").getAsString(); // filename should be constructed from partition and offset.
 
             // ====== Init HDFS File System Object
-            conf = new Configuration();
+            conf = new HdfsConfiguration();
             // Set FileSystem URI
             conf.set("fs.defaultFS", hdfsuri);
             // Because of Maven
@@ -115,7 +115,7 @@ public class HDFSWrite implements AutoCloseable {
             System.setProperty("java.security.krb5.realm", config.getKerberosRealm());
             System.setProperty("java.security.krb5.kdc", config.getKerberosHost());
 
-            conf = new Configuration();
+            conf = new HdfsConfiguration();
 
             // enable kerberus
             conf.set("hadoop.security.authentication", config.getHadoopAuthentication());

--- a/src/main/java/com/teragrep/cfe_39/consumers/kafka/HdfsDataIngestion.java
+++ b/src/main/java/com/teragrep/cfe_39/consumers/kafka/HdfsDataIngestion.java
@@ -123,6 +123,7 @@ public class HdfsDataIngestion {
             // enable kerberus
             conf.set("hadoop.security.authentication", config.getHadoopAuthentication());
             conf.set("hadoop.security.authorization", config.getHadoopAuthorization());
+            conf.set("hadoop.kerberos.keytab.login.autorenewal.enabled", "true");
             conf.set("fs.defaultFS", hdfsuri); // Set FileSystem URI
             conf.set("fs.hdfs.impl", DistributedFileSystem.class.getName()); // Maven stuff?
             conf.set("fs.file.impl", LocalFileSystem.class.getName()); // Maven stuff?

--- a/src/main/java/com/teragrep/cfe_39/consumers/kafka/HdfsDataIngestion.java
+++ b/src/main/java/com/teragrep/cfe_39/consumers/kafka/HdfsDataIngestion.java
@@ -48,10 +48,10 @@ package com.teragrep.cfe_39.consumers.kafka;
 import com.teragrep.cfe_39.Config;
 import com.teragrep.cfe_39.metrics.*;
 import com.teragrep.cfe_39.metrics.topic.TopicCounter;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.PartitionInfo;
@@ -96,7 +96,7 @@ public class HdfsDataIngestion {
             // Initializing the FileSystem with minicluster.
             String hdfsuri = config.getHdfsuri();
             // ====== Init HDFS File System Object
-            Configuration conf = new Configuration();
+            HdfsConfiguration conf = new HdfsConfiguration();
             // Set FileSystem URI
             conf.set("fs.defaultFS", hdfsuri);
             // Because of Maven
@@ -119,7 +119,7 @@ public class HdfsDataIngestion {
             // set kerberos host and realm
             System.setProperty("java.security.krb5.realm", config.getKerberosRealm());
             System.setProperty("java.security.krb5.kdc", config.getKerberosHost());
-            Configuration conf = new Configuration();
+            HdfsConfiguration conf = new HdfsConfiguration();
             // enable kerberus
             conf.set("hadoop.security.authentication", config.getHadoopAuthentication());
             conf.set("hadoop.security.authorization", config.getHadoopAuthorization());


### PR DESCRIPTION
Replaced Configuration class usage with the child class HdfsConfiguration in UserGroupInformation and FileSystem initialization.

Attempt at fixing issue #31.